### PR TITLE
Support latest Azure OpenAI models

### DIFF
--- a/src/app/bots/chatgpt-azure/index.ts
+++ b/src/app/bots/chatgpt-azure/index.ts
@@ -13,7 +13,7 @@ export class ChatGPTAzureApiBot extends AbstractChatGPTApiBot {
   }
 
   async fetchCompletionApi(messages: ChatMessage[], signal?: AbortSignal) {
-    const endpoint = `https://${this.config.azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${this.config.azureOpenAIApiDeploymentName}/chat/completions?api-version=2023-03-15-preview`
+    const endpoint = `https://${this.config.azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${this.config.azureOpenAIApiDeploymentName}/chat/completions?api-version=2023-12-01-preview`
     return fetch(endpoint, {
       method: 'POST',
       signal,
@@ -29,6 +29,10 @@ export class ChatGPTAzureApiBot extends AbstractChatGPTApiBot {
   }
 
   get name() {
-    return `ChatGPT (azure/gpt-3.5)`
+    return `ChatGPT (azure/gpt-4-1106-preview)`
+  }
+
+  getSystemMessage() {
+    return `You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possible. Knowledge cutoff: 2023-04. Current date: {current_date}`
   }
 }


### PR DESCRIPTION
Currently, ChatHub does not support GPT4-1106-preview and other latest Azure OpenAI models.
I tried to use valid API keys for a GPT4-1106-preview deployment, but the model keeps saying that its knowledge cutoff is Sept 2021.

This commit contains modifications that switches the Azure OpenAI Completion API to the latest version. It also changes the name and the system message of the bot to match the GPT4-1106-preview version.

However, it is not suitable for directly merging yet. As Azure OpenAI now supports multiple models, it would be best if users can customize the model version and the system message.