### PR TITLE
Optimize exported Markdown style, add H2

### DIFF
--- a/src/app/components/Share/MarkdownView.tsx
+++ b/src/app/components/Share/MarkdownView.tsx
@@ -13,7 +13,7 @@ const MarkdownView: FC<Props> = ({ messages }) => {
   const content = useMemo(() => {
     return messages
       .filter((m) => !!m.text)
-      .map((m) => `**${m.author}**: ` + m.text)
+      .map((m) => `## ${m.author}` + '\n\n' + m.text)
       .join('\n\n')
   }, [messages])
 


### PR DESCRIPTION
Avoid poor Markdown rendering, because GPT often outputs content with an H3 title, which looks awkward when following a user message.

I recently began taking extensive notes from ChatHub to Obsidian, so this PR will benefit people who rely on ChatHub for note-taking.

最近靠 ChatHub 总结笔记，导出的 md 格式，author 是正文，而 GPT 输出包含了多级标题，就很奇怪。
修改后： author 作为 H2

    

**before:**
![image](https://github.com/chathub-dev/chathub/assets/5327960/26fd060f-a161-490b-b71f-12cd767262c0)  

**after:**
 
![image](https://github.com/chathub-dev/chathub/assets/5327960/ed09b5de-04bb-4cd5-b5cc-956ea5c969b8)

