### PR TITLE
Fix: ReactRouter is no longer exported in higher versions

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,4 +1,4 @@
-import { createHashHistory, ReactRouter, RootRoute, Route, useParams } from '@tanstack/react-router'
+import { createHashHistory, Router as ReactRouter, RootRoute, Route, useParams } from '@tanstack/react-router'
 import { BotId } from './bots'
 import Layout from './components/Layout'
 import MultiBotChatPanel from './pages/MultiBotChatPanel'


### PR DESCRIPTION
Fix: ReactRouter is no longer exported in higher versions or fix @tanstack/react-router version to 0.0.1-beta.83

[@tanstack/react-router v0.0.1-beta.286](https://github.com/TanStack/router/blob/v0.0.1-beta.286/packages/react-router/src/router.ts) compare [@tanstack/react-router v0.0.1-beta.83](https://github.com/TanStack/router/blob/v0.0.1-beta.83/packages/react-router/src/index.tsx)